### PR TITLE
Clean up build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry>=0.12"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.isort]


### PR DESCRIPTION
**Describe what the PR does:**

Clean up build dependencies in pyproject.toml (copy of https://github.com/bachya/py17track/pull/80). Since poetry is used, setuptools and wheel should not be needed. We also only need poetry-core in a PEP 517 build.

I am hoping to clean this up for this package in [nixpkgs](https://github.com/NixOS/nixpkgs), because we are using [build](https://github.com/pypa/build) to run the build, and it validates that build dependencies are present.
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
